### PR TITLE
[RBC-411][Sprint 136] true readiness

### DIFF
--- a/sample/src/main/java/com/robotemi/sdk/sample/MainActivity.kt
+++ b/sample/src/main/java/com/robotemi/sdk/sample/MainActivity.kt
@@ -1022,6 +1022,7 @@ class MainActivity : AppCompatActivity(), NlpListener, OnRobotReadyListener,
      * Places this application in the top bar for a quick access shortcut.
      */
     override fun onRobotReady(isReady: Boolean) {
+        printLog("onRobotReady: $isReady")
         if (isReady) {
             try {
                 val activityInfo =

--- a/sdk/src/main/aidl/com/robotemi/sdk/ISdkService.aidl
+++ b/sdk/src/main/aidl/com/robotemi/sdk/ISdkService.aidl
@@ -401,4 +401,6 @@ interface ISdkService {
     int isMapLocked();
 
     int getReposeStatus();
+
+    boolean isReady();
 }

--- a/sdk/src/main/aidl/com/robotemi/sdk/ISdkService.aidl
+++ b/sdk/src/main/aidl/com/robotemi/sdk/ISdkService.aidl
@@ -402,5 +402,5 @@ interface ISdkService {
 
     int getReposeStatus();
 
-    boolean isReady();
+    int isReady();
 }

--- a/sdk/src/main/aidl/com/robotemi/sdk/ISdkServiceCallback.aidl
+++ b/sdk/src/main/aidl/com/robotemi/sdk/ISdkServiceCallback.aidl
@@ -126,4 +126,6 @@ interface ISdkServiceCallback {
     boolean onMapElementsChanged();
 
     boolean onMapNameChanged(in String mapName);
+
+    boolean onRobotReady(boolean isReady);
 }

--- a/sdk/src/main/java/com/robotemi/sdk/Robot.kt
+++ b/sdk/src/main/java/com/robotemi/sdk/Robot.kt
@@ -859,7 +859,10 @@ class Robot private constructor(private val context: Context) {
     val isReady: Boolean
         get() {
             try {
-                return sdkService?.isReady() ?: false
+                if (sdkService?.isReady() == NOT_SET) { // backward compatibility
+                    return sdkService != null
+                }
+                return sdkService?.isReady() == TRUE
             } catch (e: RemoteException) {
                 Log.e(TAG, "isNavigationBillboardDisabled() error")
             }

--- a/sdk/src/main/java/com/robotemi/sdk/Robot.kt
+++ b/sdk/src/main/java/com/robotemi/sdk/Robot.kt
@@ -864,7 +864,7 @@ class Robot private constructor(private val context: Context) {
                 }
                 return sdkService?.isReady() == TRUE
             } catch (e: RemoteException) {
-                Log.e(TAG, "isNavigationBillboardDisabled() error")
+                Log.e(TAG, "isReady() error")
             }
             return false
         }


### PR DESCRIPTION
[RBC-411](https://robocore.atlassian.net/browse/RBC-411)
This pull request includes several changes to improve the handling of the robot's readiness state in the SDK. The most important changes include adding a new method to check if the robot is ready, updating the `Robot` class to handle this new method, and adding a callback for when the robot is ready.

Improvements to readiness state handling:

* [`sdk/src/main/aidl/com/robotemi/sdk/ISdkService.aidl`](diffhunk://#diff-0972e24e9d3a7e04bcd47318890db0f5cdd09b54b7f4fb8426d8ff82ab9894ffR404-R405): Added a new method `int isReady()` to the `ISdkService` interface.
* [`sdk/src/main/aidl/com/robotemi/sdk/ISdkServiceCallback.aidl`](diffhunk://#diff-25974a7f1da3d02944f093b06b84cb894b3e561c313861770b86ac4754149f4fR129-R130): Added a new callback method `boolean onRobotReady(boolean isReady)` to the `ISdkServiceCallback` interface.

Updates to `Robot` class:

* [`sdk/src/main/java/com/robotemi/sdk/Robot.kt`](diffhunk://#diff-c529c6139397872fdecf6df5b585e52ab0d7562992e747b2cf703c4cb4ad1edaR753-R762): Added the `onRobotReady` method to notify listeners when the robot is ready.
* [`sdk/src/main/java/com/robotemi/sdk/Robot.kt`](diffhunk://#diff-c529c6139397872fdecf6df5b585e52ab0d7562992e747b2cf703c4cb4ad1edaL849-R870): Updated the `isReady` property to use the new `isReady` method from `ISdkService` for backward compatibility.
* [`sdk/src/main/java/com/robotemi/sdk/Robot.kt`](diffhunk://#diff-c529c6139397872fdecf6df5b585e52ab0d7562992e747b2cf703c4cb4ad1edaL867-R887): Modified the `onSdkServiceConnected` method to use the updated `isReady` property.

Logging improvements:

* [`sample/src/main/java/com/robotemi/sdk/sample/MainActivity.kt`](diffhunk://#diff-a0317c1ba811ed82f2402ff9a657f3165666cdd8bf3b370863b31394ce02f462R1025): Added a log statement in the `onRobotReady` method to print the readiness state.